### PR TITLE
feat: add publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Gravity UI themes for diplodoc",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/diplodoc-platform/themes",
   "bugs": {
     "url": "https://github.com/diplodoc-platform/themes/issues"


### PR DESCRIPTION
https://github.com/diplodoc-platform/themes/actions/runs/15046961001/job/42291844230 - occurs when the package is first published to the organization. By default, such a package is private, and a paid npm organization is required to publish private packages.